### PR TITLE
:bug: Deal with invalid date inputs

### DIFF
--- a/static/javascript/base.js
+++ b/static/javascript/base.js
@@ -206,3 +206,8 @@ function uuidv4() {
     (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
   )
 }
+
+/** Check that a datetime is valid */
+function validateDatetime(d) {
+  return !isNaN(d.getTime())
+}

--- a/static/javascript/map_draw.js
+++ b/static/javascript/map_draw.js
@@ -65,6 +65,11 @@ document.getElementById("submit").onclick = function () {
       content: "Route has no duration yet."
     })
     return
+  } else if (!validateDatetime(new Date(date))) {
+    populateAndShowModal({
+      title: "Submission error",
+      content: "Date is invalid."
+    })
   }
 
   const payload = {

--- a/static/javascript/map_stats.js
+++ b/static/javascript/map_stats.js
@@ -261,11 +261,25 @@ function showSegmentsWithTraversals(data, remove) {
 
 /** Parse date range inputs and whether to show the number of traversals or not. */
 function parseArgs() {
-  let startDate = document.getElementById("start-date").value
-  let endDate = document.getElementById("end-date").value
+  let startDateRaw = document.getElementById("start-date").value
+  let endDateRaw = document.getElementById("end-date").value
+
+  let startDate = new Date(startDateRaw)
+  let endDate = new Date(endDateRaw)
+  if (!validateDatetime(startDate)) {
+    populateAndShowModal({ title: "Date error", content: "Start date is invalid." })
+    return
+  } else if (!validateDatetime(endDate)) {
+    populateAndShowModal({ title: "Date error", content: "End date is invalid." })
+    return
+  } else if (startDate > endDate) {
+    populateAndShowModal({ title: "Date error", content: `End date ${endDateRaw} is prior to start date ${startDateRaw}.` })
+    return
+  }
+
   return {
-    "startDate": startDate,
-    "endDate": endDate,
+    "startDate": startDateRaw,
+    "endDate": endDateRaw,
     "numTraversals": $("#user-num-traversals").is(":checked")
   }
 }
@@ -530,6 +544,9 @@ function getRunsToShow(args, url) {
 /** Show runs completed during the date range determined by the date inputs. */
 function showInDateRange() {
   const args = parseArgs()
+  if (args === undefined) {
+    return
+  }
   const endpoint = args.numTraversals == true ? "traversals" : "runs"
   const url = endpoint + "?start_date=" + args.startDate + "&end_date=" + args.endDate
   getRunsToShow(args, url)
@@ -538,6 +555,9 @@ function showInDateRange() {
 /** Show all runs completed (in polygon if given, otherwise everwhere). */
 function showAll() {
   const args = parseArgs()
+  if (args === undefined) {
+    return
+  }
   const url = args.numTraversals == true ? "traversals" : "runs"
   getRunsToShow(args, url)
 }


### PR DESCRIPTION
Due to using date picker elements, an invalid date can only occur if a user types in one of the fields, and even then some possible failure modes can't occur, e.g. trying to type a day above 31 or month above 12 will not work. Only typing an invalid day for a shorter month, e.g. 31st November, will cause an error. In this case the date picker's value is just the empty string rather than what is visible in the date picker. The other invalid situation is when the start date is after the end date.

This resolves https://github.com/minimav/running_app/issues/5