### PR TITLE
Extract km label logic

### DIFF
--- a/static/javascript/base.js
+++ b/static/javascript/base.js
@@ -182,7 +182,6 @@ const setupPanes = (map) => {
   paneZIndexes.forEach(({ name, zIndex }) => {
     panes[name] = map.createPane(name);
     panes[name].style.zIndex = zIndex;
-    panes[name].style.pointerEvents = "none";
   });
 };
 


### PR DESCRIPTION
This is a small step towards resolving https://github.com/minimav/running_app/issues/24 through simplifying the `snapToNetwork` function, in this instance through extracting the logic that adds kilometre markers on the route.

This is also an improvement on the previous logic which only made km markers when points that the user clicked were close to an integer km, which could mean that many kms did not get a marker during long routed sections.