### PR TITLE
:bug: Fix delete_runs_by_date, id query expects data back

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -632,7 +632,11 @@ class RunningDatabase(object):
                 AND date = ?
         """
         query_params = (run_area.username, run_area.area_name, date)
-        results = self.execute(run_id_query, query_params=query_params)
+        results = self.execute(
+            run_id_query,
+            query_params=query_params,
+            expect_data=True,
+        )
         run_ids = tuple([id for id, *_ in results])
 
         placeholders = ", ".join(["?" for _ in run_ids])

--- a/src/main.py
+++ b/src/main.py
@@ -245,8 +245,8 @@ def exists_run(
 
 @app.get("/delete_run")
 def delete_run(
-    id: Optional[str],
-    date: Optional[str],
+    id: Optional[str] = None,
+    date: Optional[str] = None,
     db: RunningDatabase = Depends(database),
     current_user: models.CurrentUser = Depends(get_current_user),
 ):


### PR DESCRIPTION
Delete runs endpoint was broken since the id and date path parameters were not truly optional (needed a default) and the query for runs on a date needed `expects_data=True`.